### PR TITLE
make error message more helpful

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
 module.exports = {
     NO_EDITOR: 'There isn\'t any opened editor',
-    NO_SELECTIONS: 'There isn\t any selection',
-    NOT_ENOUGH_SELECTIONS: 'Select at least two occurrencies',
+    NO_SELECTIONS: 'There isn\'t any selection',
+    NOT_ENOUGH_SELECTIONS: 'Place cursors at two or more numbers',
     NOT_FIRST_SELECTION_NUMBER: 'The first selection must be a number'
 };


### PR DESCRIPTION
I updated the error message that said **"Select at least two occurencies"** to say **"Place cursors at two or more numbers"** because it took me a while to understand that that's what I was supposed to do. Also, added missing apostrophe for NO_SELECTIONS message.